### PR TITLE
bug fixed

### DIFF
--- a/Racoon Riot/Assets/Scenes/DEV/Ashton.unity
+++ b/Racoon Riot/Assets/Scenes/DEV/Ashton.unity
@@ -705,6 +705,79 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1510412341
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 723836286920761089, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: _parentTask
+      value: 
+      objectReference: {fileID: 73054624}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.23
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5003339734239686938, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
+      propertyPath: m_Name
+      value: Payload (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
 --- !u!1 &1517183660 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 139814076992833196, guid: 9557eb22c0c37e24da1f1d3fb1bff9ea, type: 3}
@@ -910,4 +983,5 @@ SceneRoots:
   - {fileID: 2080825228}
   - {fileID: 238933293}
   - {fileID: 1651249985}
+  - {fileID: 1510412341}
   - {fileID: 2063503835}

--- a/Racoon Riot/Assets/Scripts/Player/PickUp.cs
+++ b/Racoon Riot/Assets/Scripts/Player/PickUp.cs
@@ -45,7 +45,7 @@ public class PickUp : MonoBehaviour
     }
     public void OnTriggerEnter(Collider other)
     {
-        if(_pickUpTarget == null && other.CompareTag("PickUpObject"))
+        if(this.gameObject.GetComponent<PlayerData>().GetHeldObject() == null && other.CompareTag("PickUpObject"))
         {
             _pickUpTarget = other.gameObject;
         }


### PR DESCRIPTION
player can only pick up one object at a time now

## What does this PR do?
Re-Implemented logic to prevent multiple objects being picked up by player

## Related Issues
Fixes #178 

## Does this require changes to the main levels/menus? 
No -> All good in the land

## Additional Notes
DEV/Ashton has been supplied with 2 payload objects for testing. Can be deposited in payload receiver to remove them from player.