### PR TITLE
Added a Manual option to fracture and applied it to the task

### DIFF
--- a/Racoon Riot/Assets/OpenFracture/Runtime/Scripts/Options/TriggerOptions.cs
+++ b/Racoon Riot/Assets/OpenFracture/Runtime/Scripts/Options/TriggerOptions.cs
@@ -6,7 +6,8 @@ public enum TriggerType
 {
     Collision,
     Trigger,
-    Keyboard
+    Keyboard,
+    Manual
 }
 
 [Serializable]

--- a/Racoon Riot/Assets/Scenes/DEV/Ashton.unity
+++ b/Racoon Riot/Assets/Scenes/DEV/Ashton.unity
@@ -237,6 +237,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3626907546398529758, guid: 233ed76734a505a45837a7dacbce6ed9, type: 3}
   m_PrefabInstance: {fileID: 639563915}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &162220396 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6821977513351849507, guid: fd582a8c23198204489cfe095160844f, type: 3}
+  m_PrefabInstance: {fileID: 7863613020648531992}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &452437567
 GameObject:
   m_ObjectHideFlags: 0
@@ -467,6 +472,50 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 656535715094558290, guid: fd582a8c23198204489cfe095160844f, type: 3}
   m_PrefabInstance: {fileID: 7863613020648531992}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &765716912
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162220396}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91fc9178a0b0c3d4bb8b6d91b16d9893, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  triggerOptions:
+    triggerType: 3
+    minimumCollisionForce: 0
+    filterCollisionsByTag: 0
+    triggerAllowedTags: []
+    triggerKey: 0
+  fractureOptions:
+    fragmentCount: 10
+    xAxis: 1
+    yAxis: 1
+    zAxis: 1
+    detectFloatingFragments: 0
+    asynchronous: 0
+    insideMaterial: {fileID: 0}
+    textureScale: {x: 1, y: 1}
+    textureOffset: {x: 0, y: 0}
+    applyExplosionForce: 1
+    explosionForce: 5
+    explosionRadius: 7
+    explosionUpwardsModifier: 0
+  refractureOptions:
+    enableRefracturing: 0
+    maxRefractureCount: 1
+    invokeCallbacks: 0
+  callbackOptions:
+    onFracture:
+      m_PersistentCalls:
+        m_Calls: []
+    onCompleted:
+      m_PersistentCalls:
+        m_Calls: []
+  currentRefractureCount: 0
 --- !u!1001 &825640591
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1228,7 +1277,10 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 6821977513351849507, guid: fd582a8c23198204489cfe095160844f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 765716912}
   m_SourcePrefab: {fileID: 100100000, guid: fd582a8c23198204489cfe095160844f, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:

--- a/Racoon Riot/Assets/Scripts/Tasks/PushTask/PushTask.cs
+++ b/Racoon Riot/Assets/Scripts/Tasks/PushTask/PushTask.cs
@@ -7,9 +7,6 @@ public class PushTask : MonoBehaviour
     private TaskData _taskData;
     [SerializeField] private float _knockbackForce;
 
-    public TriggerOptions triggerOptions;
-    public FractureOptions fractureOptions;
-
     private Rigidbody _rigidbody;
     [SerializeField] private Player completingPlayer;
     [SerializeField] private float _minVelocity = 7;
@@ -39,9 +36,8 @@ public class PushTask : MonoBehaviour
             _taskData.CompleteTask(winner);
             if(_isDestructible)
             {
-                gameObject.AddComponent<Destructible>();
                 Fracture fracture = GetComponent<Fracture>();
-                fracture.fractureOptions = fractureOptions;
+                fracture.CauseFracture();
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?
Added a manual option to FractureOptions, and applied it to the PushTask. Now objects can be manually fractured by calling:
fracture.CauseFracture();
when set to manual. All other trigger types have not been touched

## Related Issues
Resolves #235 

## Does this require changes to the main levels/menus? 
No -> All good in the land